### PR TITLE
Fix: typo.

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,8 +87,8 @@ Useful resources for creating dApps and other smart contracts with RIDE language
 - [go-lib-crypto](https://github.com/wavesplatform/go-lib-crypto) - GoLang implementation of the unified crypto primitives for Waves.
 - [WavesKit](https://github.com/deemru/WavesKit) - All-in-one Waves Platform development kit for the PHP language.
 - [waves-c](https://github.com/wavesplatform/waves-c) - C library for working with Waves.
-- [WavesSDK-android](https://github.com/wavesplatform/WavesSDK-android) - SDK for Mobile Apps on Android, built using Swift.
-- [WavesSDK-iOS](https://github.com/wavesplatform/WavesSDK-iOS) - SDK for Mobile Apps on iOS, built using Kotlin.
+- [WavesSDK-android](https://github.com/wavesplatform/WavesSDK-android) - SDK for Mobile Apps on Android, built using Kotlin.
+- [WavesSDK-iOS](https://github.com/wavesplatform/WavesSDK-iOS) - SDK for Mobile Apps on iOS, built using Swift.
 
 ### Blockchain utils
 - [node-docker-image](https://github.com/wavesplatform/node-docker-image) - Docker Image for Waves Platform node. Supports MAINNET, TESTNET and CUSTOM networks.


### PR DESCRIPTION
The languages for iOS and Android development(i.e Swift and Kotlin respectively) was swapped due to a typo.